### PR TITLE
feat: respawn migration and respawn event hook

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -48,10 +48,10 @@ end
 ---Allow player to respawn
 function AllowRespawn(isInHospitalBed)
     RespawnHoldTime = 5
-    while exports['qbx-medical']:isDead() do
+    while IsDead do
         Wait(1000)
-        exports['qbx-medical']:setDeathTime(exports['qbx-medical']:getDeathTime() - 1)
-        if exports['qbx-medical']:getDeathTime() <= 0 then
+        DeathTime -= 1
+        if DeathTime <= 0 then
             if IsControlPressed(0, 38) and RespawnHoldTime <= 1 and not isInHospitalBed then
                 respawn()
             end

--- a/client/dead.lua
+++ b/client/dead.lua
@@ -35,3 +35,37 @@ function OnDeath()
 end
 
 exports('killPlayer', OnDeath)
+
+local function respawn()
+    local success = lib.callback.await('qbx-medical:server:respawn')
+    if not success then return end
+    if exports["qb-policejob"]:IsHandcuffed() then
+        TriggerEvent("police:client:GetCuffed", -1)
+    end
+    TriggerEvent("police:client:DeEscort")
+end
+
+---Allow player to respawn
+function AllowRespawn(isInHospitalBed)
+    RespawnHoldTime = 5
+    while exports['qbx-medical']:isDead() do
+        Wait(1000)
+        exports['qbx-medical']:setDeathTime(exports['qbx-medical']:getDeathTime() - 1)
+        if exports['qbx-medical']:getDeathTime() <= 0 then
+            if IsControlPressed(0, 38) and RespawnHoldTime <= 1 and not isInHospitalBed then
+                respawn()
+            end
+            if IsControlPressed(0, 38) then
+                RespawnHoldTime -= 1
+            end
+            if IsControlReleased(0, 38) then
+                RespawnHoldTime = 5
+            end
+            if RespawnHoldTime <= 1 then
+                RespawnHoldTime = 0
+            end
+        end
+    end
+end
+
+exports('allowRespawn', AllowRespawn)

--- a/client/main.lua
+++ b/client/main.lua
@@ -46,6 +46,7 @@ IsDead = false
 InLaststand = false
 DeathTime = 0
 LaststandTime = 0
+RespawnHoldTime = 5
 
 exports('getBleedLevel', function()
     return BleedLevel
@@ -113,6 +114,10 @@ end)
 
 exports('setLaststandTime', function(value)
     LaststandTime = value
+end)
+
+exports('getRespawnHoldTimeDeprecated', function()
+    return RespawnHoldTime
 end)
 
 RegisterNetEvent('hospital:client:adminHeal', function()

--- a/modules/hooks/server.lua
+++ b/modules/hooks/server.lua
@@ -19,7 +19,7 @@ if not lib then return end
 local eventHooks = {}
 local microtime = os.microtime
 
-local function TriggerEventHooks(event, payload)
+local function triggerEventHooks(event, payload)
     local hooks = eventHooks[event]
     if not hooks then return true end
 
@@ -86,4 +86,4 @@ exports('removeHooks', function(id)
 	removeResourceHooks(GetInvokingResource() or cache.resource, id)
 end)
 
-return TriggerEventHooks
+return triggerEventHooks

--- a/server/main.lua
+++ b/server/main.lua
@@ -8,6 +8,8 @@ local playerStatus = {}
 ---@type table<source, number[]> weapon hashes
 local playerWeaponWounds = {}
 
+local triggerEventHooks = require 'modules.hooks.server'
+
 ---@param data number[] weapon hashes
 RegisterNetEvent('hospital:server:SetWeaponDamage', function(data)
 	if GetInvokingResource() then return end
@@ -191,4 +193,10 @@ lib.addCommand('aheal', {
     }
 }, function(source, args)
 	triggerEventOnPlayer(source, 'hospital:client:adminHeal', args.id)
+end)
+
+lib.callback.register('qbx-medical:server:respawn', function(source)
+	if not triggerEventHooks('respawn', source) then return false end
+	exports['qbx-ambulancejob']:respawnDeprecated(source)
+	return true
 end)


### PR DESCRIPTION
- created an event hook for respawn so other resources can override behavior to deny the respawn. This could be done to implement an entirely different respawn, or just small things like denying respawn if other players are nearby.