### PR TITLE
feat(client): allow respawn migration

### DIFF
--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -5,8 +5,6 @@ function WaitForPlayerToStopMoving()
     while GetEntitySpeed(ped) > 0.5 or IsPedRagdoll(ped) do Wait(10) end
 end
 
-exports('waitForPlayerToStopMovingDeprecated', WaitForPlayerToStopMoving)
-
 --- low level GTA resurrection
 function ResurrectPlayer()
     local ped = cache.ped
@@ -21,8 +19,6 @@ function ResurrectPlayer()
     end
 end
 
-exports('resurrectPlayerDeprecated', ResurrectPlayer)
-
 ---remove last stand mode from player.
 function EndLastStand()
     local ped = cache.ped
@@ -33,3 +29,58 @@ function EndLastStand()
 end
 
 exports('endLastStandDeprecated', EndLastStand)
+
+local function logPlayerKiller()
+    local ped = cache.ped
+    local player = cache.playerId
+    local killer_2, killerWeapon = NetworkGetEntityKillerOfPlayer(player)
+    local killer = GetPedSourceOfDeath(ped)
+    if killer_2 ~= 0 and killer_2 ~= -1 then killer = killer_2 end
+    local killerId = NetworkGetPlayerIndexFromPed(killer)
+    local killerName = killerId ~= -1 and GetPlayerName(killerId) .. " " .. "(" .. GetPlayerServerId(killerId) .. ")" or Lang:t('info.self_death')
+    local weaponLabel = Lang:t('info.wep_unknown')
+    local weaponName = Lang:t('info.wep_unknown')
+    local weaponItem = QBCore.Shared.Weapons[killerWeapon]
+    if weaponItem then
+        weaponLabel = weaponItem.label
+        weaponName = weaponItem.name
+    end
+    TriggerServerEvent("qb-log:server:CreateLog", "death", Lang:t('logs.death_log_title', { playername = GetPlayerName(cache.playerId), playerid = GetPlayerServerId(player) }), "red", Lang:t('logs.death_log_message', { killername = killerName, playername = GetPlayerName(player), weaponlabel = weaponLabel, weaponname = weaponName }))
+end
+
+---count down last stand, if last stand is over, put player in death mode and log the killer.
+local function countdownLastStand()
+    
+    if LaststandTime - 1 > 0 then
+        LaststandTime -= 1
+        Config.DeathTime = LaststandTime
+    else
+        lib.notify({ description = Lang:t('error.bled_out'), type = 'error' })
+        EndLastStand()
+        logPlayerKiller()
+        DeathTime = 0
+        OnDeath()
+        AllowRespawn()
+    end
+    Wait(1000)
+end
+
+---put player in last stand mode and notify EMS.
+function StartLastStand()
+    local ped = cache.ped
+    Wait(1000)
+    WaitForPlayerToStopMoving()
+    TriggerServerEvent("InteractSound_SV:PlayOnSource", "demo", 0.1)
+    LaststandTime = Laststand.ReviveInterval
+    ResurrectPlayer()
+    SetEntityHealth(ped, 150)
+    PlayUnescortedLastStandAnimation()
+    InLaststand = true
+    TriggerServerEvent('qbx-medical:server:onPlayerLaststand')
+    CreateThread(function()
+        while InLaststand do
+            countdownLastStand()
+        end
+    end)
+    TriggerServerEvent("hospital:server:SetLaststandStatus", true)
+end

--- a/client/main.lua
+++ b/client/main.lua
@@ -58,22 +58,6 @@ exports('setBleedLevel', function(bleedLevel)
     BleedLevel = bleedLevel
 end)
 
-exports('getBleedTickTimerDeprecated', function()
-    return BleedTickTimer
-end)
-
-exports('setBleedTickTimerDeprecated', function(timer)
-    BleedTickTimer = timer
-end)
-
-exports('getAdvanceBleedTimerDeprecated', function()
-    return AdvanceBleedTimer
-end)
-
-exports('setAdvanceBleedTimerDeprecated', function(timer)
-    AdvanceBleedTimer = timer
-end)
-
 exports('getInjuries', function()
     return Injuries
 end)

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -2,7 +2,7 @@ local isEscorted = false
 local vehicleDict = "veh@low@front_ps@idle_duck"
 local vehicleAnim = "sit"
 
-local function playUnescortedLastStandAnimation()
+function PlayUnescortedLastStandAnimation()
     local ped = cache.ped
     if cache.vehicle then
         lib.requestAnimDict("vehicleDict")
@@ -36,13 +36,11 @@ local function playLastStandAnimation()
     if isEscorted then
         playEscortedLastStandAnimation(cache.ped)
     else
-        playUnescortedLastStandAnimation()
+        PlayUnescortedLastStandAnimation()
     end
 end
 
 exports('playLastStandAnimationDeprecated', playLastStandAnimation)
-
-exports('playUnescortedLastStandAnimationDeprecated', playUnescortedLastStandAnimation)
 
 ---@param bool boolean
 ---TODO: this event name should be changed within qb-policejob to be generic

--- a/config.lua
+++ b/config.lua
@@ -36,6 +36,7 @@ Config.LegInjuryChance = { -- The chance, in percent, that leg injury side-effec
     Running = 50,
     Walking = 15
 }
+Config.DeathTime = 300 -- How long the timer is for players to bleed out completely and respawn at the hospital
 
 Config.WeaponClasses = { -- Define gta weapon classe numbers
     ['SMALL_CALIBER'] = 1,


### PR DESCRIPTION
- trigger a server event for other resources to act on when player is put into last stand state
- introduce export 'disableRespawn' to replace existing check to prevent respawning while in a hospital bed. Now qbx-ambulancejob can call disableRespawn when a player is put into a bed.