### PR TITLE
chore(qbx-medical/cl): reference `qbx-` and not `qb-` for policejob

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -41,7 +41,7 @@ exports('killPlayer', OnDeath)
 local function respawn()
     local success = lib.callback.await('qbx-medical:server:respawn')
     if not success then return end
-    if exports["qb-policejob"]:IsHandcuffed() then
+    if exports["qbx-policejob"]:IsHandcuffed() then
         TriggerEvent("police:client:GetCuffed", -1)
     end
     TriggerEvent("police:client:DeEscort")


### PR DESCRIPTION
as we can see we are referencing `qb-policejob` for the `IsHandcuffed()` export which is incorrect because we are working with `qbx-policejob` now.