### PR TITLE
fix(load-unload): remove player unload

### DIFF
--- a/client/load-unload.lua
+++ b/client/load-unload.lua
@@ -37,29 +37,9 @@ local function onPlayerLoaded()
     end)
 end
 
----reset player settings that the server is storing
-local function onPlayerUnloaded()
-    local ped = cache.ped
-    TriggerServerEvent("hospital:server:SetDeathStatus", false)
-    TriggerServerEvent('hospital:server:SetLaststandStatus', false)
-    TriggerServerEvent("hospital:server:SetArmor", GetPedArmour(ped))
-    IsDead = false
-    DeathTime = 0
-    SetEntityInvincible(ped, false)
-    SetPedArmour(ped, 0)
-    ResetAllInjuries()
-end
-
 AddEventHandler('QBCore:Client:OnPlayerLoaded', onPlayerLoaded)
-
-RegisterNetEvent('QBCore:Client:OnPlayerUnload', onPlayerUnloaded)
 
 AddEventHandler('onResourceStart', function(resourceName)
     if GetCurrentResourceName() ~= resourceName then return end
     onPlayerLoaded()
-end)
-
-AddEventHandler('onResourceStop', function(resourceName)
-    if GetCurrentResourceName() ~= resourceName then return end
-    onPlayerUnloaded()
 end)


### PR DESCRIPTION
## Description

- This seems to have an effect, as it appears it is triggered in different scenarios causing the ped to die or heal/reset statuses.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
